### PR TITLE
Feat: Cache and process env support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ languages/node/**/lib
 InfisicalClient.egg-info
 
 __pycache__
+crates/infisical-py/infisical_client/schemas.py
 
 
 infisical_py.so

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,6 @@
         "./crates/infisical-c/Cargo.toml",
         "./crates/infisical-py/Cargo.toml"
     ],
-    "cSpell.words": ["infisical", "libinfisical", "openapi", "openapitools", "quicktype"],
+    "cSpell.words": ["infisical", "libinfisical", "openapi", "openapitools", "quicktype", "reqwest"],
     "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/crates/infisical-py/example.py
+++ b/crates/infisical-py/example.py
@@ -1,40 +1,23 @@
 from infisical_client import InfisicalClient, GetSecretOptions, ClientSettings, DeleteSecretOptions, CreateSecretOptions, UpdateSecretOptions, ListSecretsOptions
-
+import time
 client = InfisicalClient(ClientSettings(
-    client_id="77719230-a0b6-4590-8fbd-376e8b0898a0",
-    client_secret="4c9730a338dc64222114c473e8895311e5d34a1547e111fc173a67e418aed3a0",
-    site_url="http://localhost:8080" # This is optional. If not provided, it will default to https://app.infisical.com
+    client_id="92e6dae7-38ab-485d-8625-945a4f72c899",
+    client_secret="082ca0e72bfb8391acb834a7471e52773fab90cb61a95d10764ade9327ef347e",
+    site_url="http://localhost:8080", # This is optional. If not provided, it will default to https://app.infisical.com
+    cache_ttl=5,
 ))
 
-client.createSecret(options=CreateSecretOptions(
-    secret_name="API_KEY",
-    secret_value="Some API Key",
+client.getSecret(options=GetSecretOptions(
     environment="dev",
-    project_id="658066938ffb84aa0aa507f6"
+    project_id="6587ff06fe3abf0cb8bf1742",
+    secret_name="TEST"
 ))
 
-secret = client.getSecret(options=GetSecretOptions(
-    environment="dev",
-    project_id="658066938ffb84aa0aa507f6",
-    secret_name="API_KEY",
-    type="personal"
-))
-
-
-client.updateSecret(options=UpdateSecretOptions(
-    secret_name="API_KEY",
-    secret_value="new secret value!",
-    environment="dev",
-    project_id="658066938ffb84aa0aa507f6"
-))
-
-
-client.listSecrets(options=ListSecretsOptions(
-    environment="dev",
-    project_id="658066938ffb84aa0aa507f6",
-))
-client.deleteSecret(options=DeleteSecretOptions(
-    environment="dev",
-    project_id="658066938ffb84aa0aa507f6",
-    secret_name="API_KEY"
-))
+# Test rust multi threaded cache (should be super fast)
+while True:
+    secret = client.getSecret(options=GetSecretOptions(
+        environment="dev",
+        project_id="6587ff06fe3abf0cb8bf1742",
+        secret_name="TEST"
+    ))
+    print(secret.secret_value)

--- a/crates/infisical-py/infisical_client/infisical_client.py
+++ b/crates/infisical-py/infisical_client/infisical_client.py
@@ -7,6 +7,7 @@ from .schemas import UpdateSecretOptions, ResponseForUpdateSecretResponse
 from .schemas import DeleteSecretOptions, ResponseForDeleteSecretResponse
 from .schemas import CreateSecretOptions, ResponseForCreateSecretResponse
 import infisical_py
+import os
 
 class InfisicalClient:
     def __init__(self, settings: ClientSettings = None):
@@ -36,7 +37,13 @@ class InfisicalClient:
     def listSecrets(self, options: ListSecretsOptions) -> List[SecretElement]:
         result = self._run_command(Command(list_secrets=options))
 
-        return ResponseForListSecretsResponse.from_dict(result).data.secrets
+        secrets = ResponseForListSecretsResponse.from_dict(result).data.secrets
+
+        # Setting the env in Rust is not enough for Python apparently, so we have to do this as well.
+        for secret in secrets:
+            if(options.attach_to_process_env):
+                os.environ[secret.secret_key] = secret.secret_value
+
     
     def updateSecret(self, options: UpdateSecretOptions) -> SecretElement:
         result = self._run_command(Command(update_secret=options))

--- a/crates/infisical/src/api/secrets/list_secrets.rs
+++ b/crates/infisical/src/api/secrets/list_secrets.rs
@@ -45,6 +45,14 @@ pub async fn list_secrets_request(
     if status == StatusCode::OK {
         let response = response.json::<ListSecretsResponse>().await?;
 
+        if input.attach_to_process_env.unwrap_or(false) == true {
+            let secrets = response.secrets.clone();
+
+            for secret in secrets {
+                std::env::set_var(secret.secret_key, secret.secret_value);
+            }
+        }
+
         Ok(response)
     } else {
         let err = api_error_handler(status, response, None, false).await?;

--- a/crates/infisical/src/cache.rs
+++ b/crates/infisical/src/cache.rs
@@ -1,0 +1,149 @@
+use log::{debug, error};
+
+use crate::{manager::secrets::Secret, Client};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use std::time::{SystemTime, SystemTimeError};
+
+#[derive(Clone)]
+pub struct CachedSecret {
+    pub key: String,
+    pub secret: Secret,
+
+    // unix timestamp
+    pub expires_at: u64,
+}
+
+fn get_sys_time_in_ms() -> Result<u64, SystemTimeError> {
+    let sec = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(n) => n.as_secs(),
+        Err(e) => return Err(e),
+    };
+
+    return Ok(sec * 1000);
+}
+
+pub fn create_cache_key(secret_key: &str, secret_type: &str, environment: &str) -> String {
+    return format!("{}-{}-{}", secret_key, environment, secret_type);
+}
+
+pub fn add_to_cache(client: &mut Client, secret: &Secret) {
+    if client.cache_ttl == 0 {
+        debug!("[CACHE]: Cache TTL is set to 0, not adding secret to cache.");
+        return;
+    }
+
+    let key = create_cache_key(&secret.secret_key, &secret.r#type, &secret.environment);
+
+    let existing_secret = get_secret_from_cache(client, &key);
+
+    if existing_secret.is_some() {
+        debug!("[CACHE]: Secret already exists in cache, not adding it again.");
+        return;
+    }
+
+    let expires_at = match get_sys_time_in_ms() {
+        Ok(n) => n + (client.cache_ttl * 1000),
+        Err(e) => {
+            error!("[CACHE]: Error adding secret to cache: {}", e);
+            return;
+        }
+    };
+
+    let cached_secret = CachedSecret {
+        key,
+        expires_at,
+        secret: secret.clone(),
+    };
+
+    {
+        let mut cache = client.cache.lock().unwrap();
+        cache.push(cached_secret);
+        debug!(
+            "[CACHE]: Element added to cache, index: {:?}",
+            cache.len() - 1
+        );
+    } // Mutex lock guard is dropped here when it goes out of scope
+}
+
+// We only start this thread if the cache_ttl is greater than 0.
+pub fn cache_thread(cache: Arc<Mutex<Vec<CachedSecret>>>) {
+    let cloned_cache = Arc::clone(&cache);
+
+    std::thread::spawn(move || loop {
+        // We scope it here so it doesn't stay locked while we sleep.
+        {
+            let mut locked_cache = cloned_cache.lock().unwrap();
+
+            let current_time = match get_sys_time_in_ms() {
+                Ok(n) => n,
+                Err(e) => {
+                    error!("Error getting current time: {}", e);
+                    return;
+                }
+            };
+
+            if let Some(index) = locked_cache
+                .iter()
+                .position(|x| x.expires_at < current_time)
+            {
+                locked_cache.remove(index);
+                debug!(
+                    "[CACHE]: Element removed from cache, removed index: {:?}",
+                    index
+                );
+            }
+        }
+        // Mutex guard dropped here, allowing other threads to access the cache
+        thread::sleep(Duration::from_secs(10)); // Check every 10 seconds, this is an arbitrary number.
+    });
+}
+
+pub fn get_secret_from_cache(client: &mut Client, key: &String) -> Option<Secret> {
+    if client.cache_ttl == 0 {
+        debug!("[CACHE]: Cache TTL is set to 0, not adding secret to cache.");
+        return None;
+    }
+
+    let mut locked_cache = client.cache.lock().unwrap();
+
+    // Get index of the secret
+    let index = match locked_cache
+        .iter()
+        .position(|cached_secret| &cached_secret.key == key)
+    {
+        Some(index) => index,
+        None => return None,
+    };
+
+    // Get the new expires at time, if it fails just return no secret.
+    let expires_at = match get_sys_time_in_ms() {
+        Ok(n) => n + (client.cache_ttl * 1000),
+        Err(e) => {
+            error!(
+                "[CACHE]: Error getting new expiry date for cache element: {}",
+                e
+            );
+            return None;
+        }
+    };
+
+    let secret = locked_cache[index].secret.clone();
+
+    // Create a new cached secret
+    let cached_secret = CachedSecret {
+        key: key.to_string(),
+        expires_at,
+        secret: secret.clone(),
+    };
+
+    locked_cache.remove(index); // Remove the old cached secret
+    locked_cache.push(cached_secret); // Add the new cached secret
+
+    debug!(
+        "[CACHE]: Found cached secret with cache key, and updated the expiry time on it: {}",
+        key
+    );
+    return Some(secret);
+}

--- a/crates/infisical/src/client/client_settings.rs
+++ b/crates/infisical/src/client/client_settings.rs
@@ -8,10 +8,12 @@ pub struct ClientSettings {
     // These are optional because the access token can be set directly as well
     pub client_secret: Option<String>,
     pub client_id: Option<String>,
-
-    // Access token is optional because the user can also provide maci
     pub access_token: Option<String>,
+
+    // Access token is optional because the user can also provide a machine token.
     pub site_url: Option<String>,
+
+    pub cache_ttl: Option<u64>, // This controls how often the cache should refresh, default is 300 seconds
 }
 
 impl Default for ClientSettings {
@@ -21,6 +23,7 @@ impl Default for ClientSettings {
             client_id: None,
             access_token: None,
             site_url: None,
+            cache_ttl: None,
         }
     }
 }

--- a/crates/infisical/src/lib.rs
+++ b/crates/infisical/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod api;
 pub use api::access_token;
 
+pub mod cache;
+
 pub mod auth;
 pub mod client;
 pub mod error;

--- a/crates/infisical/src/manager/secrets/list.rs
+++ b/crates/infisical/src/manager/secrets/list.rs
@@ -13,6 +13,7 @@ pub struct ListSecretsOptions {
     pub project_id: String,
     pub path: Option<String>,
 
+    pub attach_to_process_env: Option<bool>,
     pub include_imports: Option<bool>,
 }
 

--- a/crates/infisical/src/manager/secrets/mod.rs
+++ b/crates/infisical/src/manager/secrets/mod.rs
@@ -13,7 +13,7 @@ pub use update::{UpdateSecretOptions, UpdateSecretResponse};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Secret {
     pub version: i32,

--- a/crates/infisical/tests/secrets.rs
+++ b/crates/infisical/tests/secrets.rs
@@ -84,6 +84,7 @@ fn create_client() -> Client {
         client_secret: Some(client_secret.unwrap()),
         access_token: None,
         site_url: None,
+        cache_ttl: None,
     };
 
     let client = Client::new(Some(settings));
@@ -198,6 +199,7 @@ mod tests {
             project_id: project_id.to_string(),
             path: None,
             include_imports: None,
+            attach_to_process_env: None,
         };
 
         let dummy_secret = create_dummy_secret(&mut client).await;

--- a/languages/node/example.ts
+++ b/languages/node/example.ts
@@ -1,75 +1,50 @@
-import { InfisicalClient, LogLevel } from "./src";
+import { GetSecretOptions, InfisicalClient, LogLevel } from "./src";
 
 // Just need a random string for testing, nothing crazy.
 const randomStr = () => Date.now().toString(36);
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const client = new InfisicalClient({
+    clientId: "92e6dae7-38ab-485d-8625-945a4f72c899",
+    clientSecret: "082ca0e72bfb8391acb834a7471e52773fab90cb61a95d10764ade9327ef347e",
+    siteUrl: "http://localhost:8080",
+    cacheTtl: 10,
+    logLevel: LogLevel.Debug
+});
 
 (async () => {
-    const client = new InfisicalClient({
-        clientId: "77719230-a0b6-4590-8fbd-376e8b0898a0",
-        clientSecret: "4c9730a338dc64222114c473e8895311e5d34a1547e111fc173a67e418aed3a0",
-        siteUrl: "http://localhost:8080",
-        logLevel: LogLevel.Debug
-    });
-
-    const newSecretName = "123";
-    const projectId = "658066938ffb84aa0aa507f6";
+    const projectId = "6587ff06fe3abf0cb8bf1742";
     const environment = "dev";
 
-    const newSecret = await client.createSecret({
-        environment,
-        projectId,
+    await client.listSecrets({ projectId, environment, attachToProcessEnv: true });
 
-        secretName: newSecretName,
-        secretValue: "test"
-    });
+    console.log(process.env);
 
-    console.log("Created secret:", newSecret);
-    console.log("\n\n\n\n\n\n\n\n\n");
+    /*
+    while (true) {
+        const promises: any = [];
+        for (let i = 0; i < 1; i++) {
+            promises.push(runTests());
+        }
 
-    const secret = await client.getSecret({
-        environment,
-        projectId,
-
-        secretName: newSecretName
-    });
-
-    console.log("Got secret:", secret);
-    console.log("\n\n\n\n\n\n\n\n\n");
-
-    const secrets = await client.listSecrets({
-        environment,
-        projectId
-    });
-
-    console.log("Listed secrets:", secrets);
-    console.log("\n\n\n\n\n\n\n\n\n");
-
-    const updatedSecret = await client.updateSecret({
-        environment,
-        projectId,
-
-        secretName: newSecretName,
-        secretValue: "NEW VALUE"
-    });
-
-    console.log("Updated secret:", updatedSecret);
-    console.log("\n\n\n\n\n\n\n\n\n");
-
-    /* const deletedSecret = await client.deleteSecret({
-        environment,
-        projectId,
-
-        secretName: secretName
-    });*/
-
-    //console.log("Deleted secret:", deletedSecret);
-    console.log("\n\n\n\n\n\n\n\n\n");
-
-    const secretsAfterDelete = await client.listSecrets({
-        environment,
-        projectId
-    });
-
-    console.log("Listed secrets after delete:", secretsAfterDelete);
-    console.log("\n\n\n\n\n\n\n\n\n");
+        await Promise.all(promises);
+    }*/
 })();
+
+async function runTests() {
+    const secretNames = ["TEST", "TEST2", "TEST3", "TEST4", "TEST5", "TEST6"];
+    let promises: any = [];
+
+    for (let i = 0; i++ < 10; i++) {
+        const options: GetSecretOptions = {
+            environment: "dev",
+            projectId: "6587ff06fe3abf0cb8bf1742",
+
+            secretName: secretNames[Math.floor(Math.random() * secretNames.length)]
+        };
+
+        promises.push(await client.getSecret(options));
+    }
+
+    await Promise.all(promises);
+}


### PR DESCRIPTION
This PR introduces secret caching like we had in the now deprecated Node SDK. Additionally it also supports attaching secrets to the process env, however this is still in beta. Currently it only works natively with Node.js, and some extra code was needed to make it work for Python. Java it doesn't work at all for. 