### PR TITLE
User agents for SDK's

### DIFF
--- a/crates/infisical-py/infisical_client/infisical_client.py
+++ b/crates/infisical-py/infisical_client/infisical_client.py
@@ -21,6 +21,9 @@ class InfisicalClient:
         if settings is None:
             self.inner = infisical_py.InfisicalClient(None)
         else:
+
+            settings.user_agent = "infisical-python-sdk"
+
             settings_json = json.dumps(settings.to_dict())
 
             self.inner = infisical_py.InfisicalClient(settings_json)

--- a/crates/infisical/src/api/access_token.rs
+++ b/crates/infisical/src/api/access_token.rs
@@ -37,7 +37,8 @@ pub async fn access_token_request(client: &mut Client) -> Result<AccessTokenSucc
     let request = req_client
         .post(url)
         .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header(reqwest::header::ACCEPT, "application/json");
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::USER_AGENT, client.user_agent.clone());
 
     let response = request.body(object).send().await?;
 

--- a/crates/infisical/src/client/client.rs
+++ b/crates/infisical/src/client/client.rs
@@ -15,6 +15,7 @@ pub struct Client {
     pub(crate) cache_ttl: u64, // No need for a mutex lock here, as we are only reading this value in the cache thread.
 
     pub site_url: String,
+    pub user_agent: String,
 }
 
 impl Client {
@@ -33,6 +34,7 @@ impl Client {
 
             cache: Arc::new(Mutex::new(Vec::new())),
             cache_ttl: settings.cache_ttl.unwrap_or(300),
+            user_agent: settings.user_agent.unwrap(),
         };
 
         if c.cache_ttl != 0 {

--- a/crates/infisical/src/client/client_settings.rs
+++ b/crates/infisical/src/client/client_settings.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(default, rename_all = "camelCase")]
-#[cfg_attr(feature = "mobile", derive(uniffi::Record))]
 pub struct ClientSettings {
     // These are optional because the access token can be set directly as well
     pub client_secret: Option<String>,
@@ -14,6 +13,7 @@ pub struct ClientSettings {
     pub site_url: Option<String>,
 
     pub cache_ttl: Option<u64>, // This controls how often the cache should refresh, default is 300 seconds
+    pub user_agent: Option<String>, // We use this to identity which SDK/language was used to make a request.
 }
 
 impl Default for ClientSettings {
@@ -24,6 +24,7 @@ impl Default for ClientSettings {
             access_token: None,
             site_url: None,
             cache_ttl: None,
+            user_agent: Some("infisical-unknown-sdk".to_string()),
         }
     }
 }

--- a/crates/infisical/src/helper.rs
+++ b/crates/infisical/src/helper.rs
@@ -33,7 +33,8 @@ pub fn build_base_request(
         // Setting JSON as the content type is OK since we only work with JSON.
         .header(reqwest::header::CONTENT_TYPE, "application/json")
         .header(reqwest::header::ACCEPT, "application/json")
-        .header("Authorization", token);
+        .header("Authorization", token)
+        .header(reqwest::header::USER_AGENT, client.user_agent.clone());
 
     // we need to be able to do .json() on this request
     // .json(json)

--- a/crates/infisical/tests/cryptography.rs
+++ b/crates/infisical/tests/cryptography.rs
@@ -35,6 +35,7 @@ fn create_client() -> Client {
         access_token: None,
         site_url: Some(environment.site_url),
         cache_ttl: None,
+        user_agent: Some("infisical-cryptography-test-sdk".to_string()),
     };
 
     let client = Client::new(Some(settings));

--- a/crates/infisical/tests/secrets.rs
+++ b/crates/infisical/tests/secrets.rs
@@ -106,6 +106,7 @@ fn create_client() -> Client {
         access_token: None,
         site_url: Some(environment.site_url),
         cache_ttl: None,
+        user_agent: Some("infisical-secrets-test-sdk".to_string()),
     };
 
     let client = Client::new(Some(settings));

--- a/languages/java/src/main/java/com/infisical/sdk/InfisicalClient.java
+++ b/languages/java/src/main/java/com/infisical/sdk/InfisicalClient.java
@@ -16,6 +16,8 @@ public class InfisicalClient implements AutoCloseable {
 
     public InfisicalClient(ClientSettings settings) {
 
+        settings.setUserAgent("infisical-java-sdk");
+
         library = Native.load("infisical_c", InfisicalLibrary.class);
 
         try {

--- a/languages/node/src/infisical_client/index.ts
+++ b/languages/node/src/infisical_client/index.ts
@@ -15,6 +15,9 @@ export class InfisicalClient {
     #client: rust.InfisicalClient;
 
     constructor(settings: ClientSettings & { logLevel?: LogLevel }) {
+
+        settings.userAgent = "infisical-nodejs-sdk";
+
         const settingsJson = settings == null ? null : Convert.clientSettingsToJson(settings);
         this.#client = new rust.InfisicalClient(settingsJson, settings.logLevel ?? LogLevel.Error);
     }


### PR DESCRIPTION
What: Added user agents to all SDK's. Agent will depend on SDK language. This way we can identity which SDK's are sending requests to our API.