### PR TITLE
Fix unwraps in Client

### DIFF
--- a/crates/infisical/src/client/client.rs
+++ b/crates/infisical/src/client/client.rs
@@ -20,7 +20,7 @@ pub struct Client {
 
 impl Client {
     pub fn new(settings_input: Option<ClientSettings>) -> Self {
-        let settings = settings_input.unwrap();
+        let settings = settings_input.unwrap(); // show an error to set the .env? Not actually sure how this throws
 
         let c = Self {
             auth: ClientAuth {
@@ -34,7 +34,7 @@ impl Client {
 
             cache: Arc::new(Mutex::new(Vec::new())),
             cache_ttl: settings.cache_ttl.unwrap_or(300),
-            user_agent: settings.user_agent.unwrap(),
+            user_agent: settings.user_agent.unwrap_or("".to_string()),
         };
 
         if c.cache_ttl != 0 {
@@ -44,9 +44,11 @@ impl Client {
     }
 
     pub fn set_cache(&self, new_cache: &[CachedSecret]) {
-        let mut cache = self.cache.lock().unwrap();
-        cache.clear();
-        cache.extend(new_cache.iter().cloned());
+        let cache = self.cache.lock();
+        if let Ok(mut cache) = cache {
+            cache.clear();
+            cache.extend(new_cache.iter().cloned());
+        } // failing silently in this change. if a lock cannot be acquired, there can also be an error thrown here.
     }
 
     pub fn set_access_token(&mut self, token: String) {

--- a/crates/infisical/src/client/client.rs
+++ b/crates/infisical/src/client/client.rs
@@ -20,8 +20,7 @@ pub struct Client {
 
 impl Client {
     pub fn new(settings_input: Option<ClientSettings>) -> Self {
-        let settings = settings_input.unwrap(); // show an error to set the .env? Not actually sure how this throws
-
+        let settings = settings_input.unwrap(); 
         let c = Self {
             auth: ClientAuth {
                 client_id: settings.client_id.unwrap_or("".to_string()),
@@ -41,14 +40,6 @@ impl Client {
             cache_thread(Arc::clone(&c.cache));
         }
         return c;
-    }
-
-    pub fn set_cache(&self, new_cache: &[CachedSecret]) {
-        let cache = self.cache.lock();
-        if let Ok(mut cache) = cache {
-            cache.clear();
-            cache.extend(new_cache.iter().cloned());
-        } // failing silently in this change. if a lock cannot be acquired, there can also be an error thrown here.
     }
 
     pub fn set_access_token(&mut self, token: String) {


### PR DESCRIPTION
**Feel free to edit any one of these**

In the initialization of a `Client` there is an `unwrap` that I am not sure what to do with besides maybe throwing a specific error to the user that something went wrong with the environment variables or project config.

I added an additional `unwrap_or` so the entire initialization of the client has default values, but this behavior might not be desired and can be removed if no `user_agent` should throw an error.

Lastly, if a lock can't be acquire on the `Mutex` then another thread is using it, and I think the behavior should be the cache does not change, and there is no error. (as opposed to the unwrap)

