### PR TITLE
(Feat): Add fallback secret & fix include imports

### DIFF
--- a/crates/infisical/src/api/secrets/get_secret.rs
+++ b/crates/infisical/src/api/secrets/get_secret.rs
@@ -1,6 +1,6 @@
 use crate::cache::{add_to_cache, create_cache_key, get_secret_from_cache};
 use crate::error::api_error_handler;
-use crate::helper::{build_base_request, build_url};
+use crate::helper::{build_base_request, build_url, get_fallback_env_secret};
 use crate::manager::secrets::{GetSecretOptions, GetSecretResponse};
 use crate::{error::Result, Client};
 use log::debug;
@@ -69,6 +69,14 @@ pub async fn get_secret_request(
 
         Ok(response)
     } else {
+        let fallback_secret = get_fallback_env_secret(&input.secret_name);
+
+        if fallback_secret.is_some() {
+            return Ok(GetSecretResponse {
+                secret: fallback_secret.unwrap(),
+            });
+        }
+
         let err =
             api_error_handler(status, response, Some(input.secret_name.clone()), false).await?;
         Err(err)

--- a/crates/infisical/src/api/secrets/list_secrets.rs
+++ b/crates/infisical/src/api/secrets/list_secrets.rs
@@ -1,9 +1,25 @@
 use crate::error::api_error_handler;
 use crate::helper::{build_base_request, build_url};
-use crate::manager::secrets::{ListSecretsOptions, ListSecretsResponse};
+use crate::manager::secrets::{ListSecretsOptions, ListSecretsResponse, Secret};
 use crate::{error::Result, Client};
 use log::debug;
 use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ListSecretsResponseImports {
+    secret_path: String,
+    folder_id: String,
+    environment: String,
+    secrets: Vec<Secret>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct ImportResponse {
+    pub(crate) imports: Vec<ListSecretsResponseImports>,
+    pub(crate) secrets: Vec<Secret>,
+}
 
 pub async fn list_secrets_request(
     client: &mut Client,
@@ -16,7 +32,7 @@ pub async fn list_secrets_request(
         "workspaceId": input.project_id,
 
         "secretPath": input.path.as_ref().unwrap_or(&"/".to_string()), // default is "/"
-        "include_imports": input.include_imports.as_ref().unwrap_or(&false), // default is false
+        "include_imports": input.include_imports.unwrap_or(false).to_string(),
 
     });
 
@@ -43,6 +59,24 @@ pub async fn list_secrets_request(
     let status = response.status();
 
     if status == StatusCode::OK {
+        if input.include_imports.unwrap_or(false) == true {
+            let response = response.json::<ImportResponse>().await?;
+
+            let mut secrets = response.secrets.clone();
+
+            for import in response.imports {
+                secrets.extend(import.secrets);
+            }
+
+            if input.attach_to_process_env.unwrap_or(false) == true {
+                for secret in secrets.clone() {
+                    std::env::set_var(secret.secret_key, secret.secret_value);
+                }
+            }
+
+            return Ok(ListSecretsResponse { secrets });
+        }
+
         let response = response.json::<ListSecretsResponse>().await?;
 
         if input.attach_to_process_env.unwrap_or(false) == true {

--- a/crates/infisical/src/helper.rs
+++ b/crates/infisical/src/helper.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::access_token::access_token_request,
     error::{Error, Result},
+    manager::secrets::Secret,
     Client,
 };
 use log::debug;
@@ -80,4 +81,28 @@ pub fn build_url(url: String, query_params: &serde_json::Value) -> String {
     }
 
     return url.to_string();
+}
+
+pub fn get_fallback_env_secret(key: &str) -> Option<Secret> {
+    let fallback = std::env::var(key);
+
+    let default_secret = Secret {
+        is_fallback: true,
+        version: 0,
+        workspace: "".to_string(),
+        secret_comment: "".to_string(),
+        r#type: "".to_string(),
+        environment: "".to_string(),
+
+        secret_key: key.to_string(),
+        secret_value: "".to_string(),
+    };
+
+    match fallback {
+        Ok(val) => Some(Secret {
+            secret_value: val,
+            ..default_secret
+        }),
+        Err(_) => None,
+    }
 }

--- a/crates/infisical/src/manager/secrets/mod.rs
+++ b/crates/infisical/src/manager/secrets/mod.rs
@@ -13,6 +13,11 @@ pub use update::{UpdateSecretOptions, UpdateSecretResponse};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+// This is a hack, because Serde can't parse boolean values by default...
+fn default_as_false() -> bool {
+    false
+}
+
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Secret {
@@ -23,4 +28,7 @@ pub struct Secret {
     pub secret_key: String,
     pub secret_value: String,
     pub secret_comment: String,
+
+    #[serde(default = "default_as_false")]
+    pub is_fallback: bool,
 }

--- a/languages/node/src/infisical_client/index.ts
+++ b/languages/node/src/infisical_client/index.ts
@@ -15,7 +15,6 @@ export class InfisicalClient {
     #client: rust.InfisicalClient;
 
     constructor(settings: ClientSettings & { logLevel?: LogLevel }) {
-
         settings.userAgent = "infisical-nodejs-sdk";
 
         const settingsJson = settings == null ? null : Convert.clientSettingsToJson(settings);


### PR DESCRIPTION
This PR has two main focus points, being included imports and fallback secrets.

### Fallback secrets
When using the `getSecret` method, the SDK will now attempt to check the local env on the user's machine. An example would be that the user tries to find a `GITHUB_TOKEN` variable with the `getSecret` method. However this secret isn't on Infisical. Instead of just returning an error, we now check the process environment, and return a successful response if we find a matching key.

### Include imports
There's currently an issue with include imports, preventing the `includeImports` parameter from working. This update introduces a fix for this, resulting in functionality that mimics the old Node.js SDK.
