### PR TITLE
Fix: Caching path bug #29

### DIFF
--- a/crates/infisical/src/api/secrets/create_secret.rs
+++ b/crates/infisical/src/api/secrets/create_secret.rs
@@ -58,6 +58,7 @@ pub async fn create_secret_request(
             &response.secret.secret_key,
             &response.secret.r#type,
             &response.secret.environment,
+            input.path.as_ref().unwrap_or(&"/".to_string()),
         );
 
         Ok(response)

--- a/crates/infisical/src/api/secrets/delete_secret.rs
+++ b/crates/infisical/src/api/secrets/delete_secret.rs
@@ -51,6 +51,7 @@ pub async fn delete_secret_request(
             &response.secret.secret_key,
             &response.secret.r#type,
             &response.secret.environment,
+            input.path.as_ref().unwrap_or(&"/".to_string()),
         );
 
         Ok(response)

--- a/crates/infisical/src/api/secrets/update_secret.rs
+++ b/crates/infisical/src/api/secrets/update_secret.rs
@@ -45,6 +45,7 @@ pub async fn update_secret_request(
             &response.secret.secret_key,
             &response.secret.r#type,
             &response.secret.environment,
+            input.path.as_ref().unwrap_or(&"/".to_string()),
         );
 
         Ok(response)

--- a/crates/infisical/src/cache.rs
+++ b/crates/infisical/src/cache.rs
@@ -24,17 +24,30 @@ fn get_sys_time_in_ms() -> Result<u64, SystemTimeError> {
     return Ok(sec * 1000);
 }
 
-pub fn create_cache_key(secret_key: &str, secret_type: &str, environment: &str) -> String {
-    return format!("{}-{}-{}", secret_key, environment, secret_type);
+pub fn create_cache_key(
+    secret_key: &str,
+    secret_type: &str,
+    environment: &str,
+    secret_path: &str,
+) -> String {
+    return format!(
+        "{}-{}-{}-{}",
+        secret_key, environment, secret_type, secret_path
+    );
 }
 
-pub fn add_to_cache(client: &mut Client, secret: &Secret) {
+pub fn add_to_cache(client: &mut Client, secret: &Secret, secret_path: &str) {
     if client.cache_ttl == 0 {
         debug!("[CACHE]: Cache TTL is set to 0, not adding secret to cache.");
         return;
     }
 
-    let key = create_cache_key(&secret.secret_key, &secret.r#type, &secret.environment);
+    let key = create_cache_key(
+        &secret.secret_key,
+        &secret.r#type,
+        &secret.environment,
+        secret_path,
+    );
 
     let existing_secret = get_secret_from_cache(client, &key);
 
@@ -72,13 +85,14 @@ pub fn remove_from_cache(
     secret_key: &str,
     secret_type: &str,
     environment: &str,
+    secret_path: &str,
 ) {
     if client.cache_ttl == 0 {
         debug!("[CACHE]: Cache TTL is set to 0, not removing secret from cache.");
         return;
     }
 
-    let key = create_cache_key(&secret_key, &secret_type, &environment);
+    let key = create_cache_key(secret_key, secret_type, environment, secret_path);
 
     let mut cache = client.cache.lock().unwrap();
 

--- a/crates/infisical/src/helper.rs
+++ b/crates/infisical/src/helper.rs
@@ -182,6 +182,7 @@ pub fn get_fallback_env_secret(key: &str) -> Option<Secret> {
         secret_comment: "".to_string(),
         r#type: "".to_string(),
         environment: "".to_string(),
+        secret_path: None,
 
         secret_key: key.to_string(),
         secret_value: "".to_string(),

--- a/crates/infisical/src/manager/secrets/mod.rs
+++ b/crates/infisical/src/manager/secrets/mod.rs
@@ -30,7 +30,7 @@ pub struct Secret {
     pub secret_comment: String,
 
     #[schemars(
-        description = "The path of the secret\n\nNote that this will only be present when using the `list secrets` method."
+        description = "The path of the secret.\n\nNote that this will only be present when using the `list secrets` method."
     )]
     pub secret_path: Option<String>,
 

--- a/crates/infisical/src/manager/secrets/mod.rs
+++ b/crates/infisical/src/manager/secrets/mod.rs
@@ -29,6 +29,11 @@ pub struct Secret {
     pub secret_value: String,
     pub secret_comment: String,
 
+    #[schemars(
+        description = "The path of the secret\n\nNote that this will only be present when using the `list secrets` method."
+    )]
+    pub secret_path: Option<String>,
+
     #[serde(default = "default_as_false")]
     pub is_fallback: bool,
 }


### PR DESCRIPTION
This PR addresses #29. Currently the cache doesn't take the secret path into account. This PR resolves this issue by adding the secret path as a factor in the cache keying.  