### PR TITLE
feat: Custom TLS certificate support

### DIFF
--- a/crates/infisical/src/api/auth/azure_login.rs
+++ b/crates/infisical/src/api/auth/azure_login.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     constants::AZURE_METADATA_SERVICE_URL,
     error::{api_error_handler, Result},
+    helper::build_minimal_base_request,
     Client,
 };
 
@@ -17,10 +18,7 @@ pub async fn azure_login(
     client: &mut Client,
     identity_id: String,
 ) -> Result<AccessTokenSuccessResponse> {
-    let request_client = reqwest::Client::builder()
-        .use_preconfigured_tls(rustls_platform_verifier::tls_config())
-        .build()
-        .unwrap();
+    let request_client = build_minimal_base_request()?;
 
     let metadata_request = request_client
         .get(AZURE_METADATA_SERVICE_URL)

--- a/crates/infisical/src/api/auth/gcp_id_token_login.rs
+++ b/crates/infisical/src/api/auth/gcp_id_token_login.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::auth::auth_infisical_google,
     error::{api_error_handler, Error, Result},
+    helper::build_minimal_base_request,
     Client,
 };
 
@@ -10,10 +11,7 @@ pub async fn gcp_id_token_login(
     client: &mut Client,
     identity_id: String,
 ) -> Result<AccessTokenSuccessResponse> {
-    let request_client = reqwest::Client::builder()
-        .use_preconfigured_tls(rustls_platform_verifier::tls_config())
-        .build()
-        .unwrap();
+    let request_client = build_minimal_base_request()?;
 
     let metadata_request = request_client
         .get(format!(

--- a/crates/infisical/src/api/auth/mod.rs
+++ b/crates/infisical/src/api/auth/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{Error, Result},
+    helper::build_base_request,
     Client,
 };
 
@@ -46,15 +47,10 @@ pub(self) async fn auth_infisical_google(
     identity_id: Option<String>,
     jwt: Option<String>,
 ) -> Result<reqwest::Response> {
-    let request_client = reqwest::Client::builder()
-        .use_preconfigured_tls(rustls_platform_verifier::tls_config())
-        .build()?;
+    let url = format!("{}/api/v1/auth/gcp-auth/login", client.site_url.clone());
+    let request_client = build_base_request(client, &url, reqwest::Method::POST).await?;
 
     let request = request_client
-        .post(format!(
-            "{}/api/v1/auth/gcp-auth/login",
-            client.site_url.clone()
-        ))
         .header(reqwest::header::ACCEPT, "application/json")
         .header(reqwest::header::USER_AGENT, client.user_agent.clone());
 
@@ -72,15 +68,10 @@ pub(self) async fn auth_infisical_azure(
     identity_id: Option<String>,
     jwt: Option<String>,
 ) -> Result<reqwest::Response> {
-    let request_client = reqwest::Client::builder()
-        .use_preconfigured_tls(rustls_platform_verifier::tls_config())
-        .build()?;
+    let url = format!("{}/api/v1/auth/azure-auth/login", client.site_url.clone());
+    let request_client = build_base_request(client, &url, reqwest::Method::POST).await?;
 
     let request = request_client
-        .post(format!(
-            "{}/api/v1/auth/azure-auth/login",
-            client.site_url.clone()
-        ))
         .header(reqwest::header::ACCEPT, "application/json")
         .header(reqwest::header::USER_AGENT, client.user_agent.clone());
 
@@ -98,15 +89,13 @@ pub(self) async fn auth_infisical_kubernetes(
     identity_id: Option<String>,
     jwt: Option<String>,
 ) -> Result<reqwest::Response> {
-    let request_client = reqwest::Client::builder()
-        .use_preconfigured_tls(rustls_platform_verifier::tls_config())
-        .build()?;
+    let url = format!(
+        "{}/api/v1/auth/kubernetes-auth/login",
+        client.site_url.clone()
+    );
+    let request_client = build_base_request(client, &url, reqwest::Method::POST).await?;
 
     let request = request_client
-        .post(format!(
-            "{}/api/v1/auth/kubernetes-auth/login",
-            client.site_url.clone()
-        ))
         .header(reqwest::header::ACCEPT, "application/json")
         .header(reqwest::header::USER_AGENT, client.user_agent.clone());
 
@@ -133,9 +122,8 @@ pub(self) async fn auth_infisical_aws(
     let iam_headers = base64_encode(header_json);
     let request_body = base64_encode(iam_data.iam_request_body.clone());
 
-    let request_client = reqwest::Client::builder()
-        .use_preconfigured_tls(rustls_platform_verifier::tls_config())
-        .build()?;
+    let url = format!("{}/api/v1/auth/aws-auth/login", client.site_url.clone());
+    let request_client = build_base_request(client, &url, reqwest::Method::POST).await?;
 
     let mut form_data = HashMap::new();
 
@@ -145,10 +133,6 @@ pub(self) async fn auth_infisical_aws(
     form_data.insert("iamRequestHeaders", Some(iam_headers));
 
     let request = request_client
-        .post(format!(
-            "{}/api/v1/auth/aws-auth/login",
-            client.site_url.clone()
-        ))
         .header(reqwest::header::ACCEPT, "application/json")
         .header(reqwest::header::USER_AGENT, client.user_agent.clone());
 

--- a/crates/infisical/src/api/auth/universal_auth_login.rs
+++ b/crates/infisical/src/api/auth/universal_auth_login.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::{api_error_handler, Result},
+    helper::build_base_request,
     Client,
 };
 use log::debug;
@@ -23,12 +24,9 @@ pub async fn universal_auth_login(
         client.site_url.clone()
     );
 
-    let request_client = reqwest::Client::builder()
-        .use_preconfigured_tls(rustls_platform_verifier::tls_config())
-        .build()?;
+    let request_client = build_base_request(client, &url, reqwest::Method::POST).await?;
 
     let request = request_client
-        .post(url)
         .header(reqwest::header::CONTENT_TYPE, "application/json")
         .header(reqwest::header::ACCEPT, "application/json")
         .header(reqwest::header::USER_AGENT, client.user_agent.clone());

--- a/crates/infisical/src/api/secrets/create_secret.rs
+++ b/crates/infisical/src/api/secrets/create_secret.rs
@@ -29,12 +29,7 @@ pub async fn create_secret_request(
 
     });
 
-    let base_request = build_base_request(client, &base_url, reqwest::Method::POST);
-
-    let request = match base_request {
-        Ok(request) => request,
-        Err(e) => return Err(e),
-    };
+    let base_request = build_base_request(client, &base_url, reqwest::Method::POST).await?;
 
     let token = match client.auth.access_token {
         Some(ref token) => format!("Bearer {}", token),
@@ -46,7 +41,7 @@ pub async fn create_secret_request(
     debug!("Creating secret with JSON body: {:?}", json);
     debug!("Creating secret with url: {}", base_url);
 
-    let response = request.json(json).send().await?;
+    let response = base_request.json(json).send().await?;
     let status = response.status();
 
     if status == StatusCode::OK {

--- a/crates/infisical/src/api/secrets/delete_secret.rs
+++ b/crates/infisical/src/api/secrets/delete_secret.rs
@@ -23,12 +23,7 @@ pub async fn delete_secret_request(
         "secretPath": input.path.as_ref().unwrap_or(&"/".to_string()),
     });
 
-    let base_request = build_base_request(client, &base_url, reqwest::Method::DELETE);
-
-    let request = match base_request {
-        Ok(request) => request,
-        Err(e) => return Err(e),
-    };
+    let base_request = build_base_request(client, &base_url, reqwest::Method::DELETE).await?;
 
     let token = match client.auth.access_token {
         Some(ref token) => format!("Bearer {}", token),
@@ -39,7 +34,7 @@ pub async fn delete_secret_request(
     debug!("Creating secret with JSON body: {:?}", json);
     debug!("Creating secret with url: {}", base_url);
 
-    let response = request.json(json).send().await?;
+    let response = base_request.json(json).send().await?;
     let status = response.status();
 
     if status == StatusCode::OK {

--- a/crates/infisical/src/api/secrets/get_secret.rs
+++ b/crates/infisical/src/api/secrets/get_secret.rs
@@ -52,7 +52,7 @@ pub async fn get_secret_request(
 
     let url = build_url(base_url, json);
 
-    let base_request = build_base_request(client, &url, reqwest::Method::GET);
+    let base_request = build_base_request(client, &url, reqwest::Method::GET).await?;
 
     let token = match client.auth.access_token {
         Some(ref token) => format!("Bearer {}", token),
@@ -64,12 +64,7 @@ pub async fn get_secret_request(
     debug!("Getting secret with body: {:?}", input);
     debug!("Getting secret with url: {}", url);
 
-    let request = match base_request {
-        Ok(request) => request,
-        Err(e) => return Err(e),
-    };
-
-    let response = request.send().await?;
+    let response = base_request.send().await?;
 
     let status = response.status();
 

--- a/crates/infisical/src/api/secrets/list_secrets.rs
+++ b/crates/infisical/src/api/secrets/list_secrets.rs
@@ -39,13 +39,7 @@ pub async fn list_secrets_request(
     });
 
     let url = &build_url(base_url, json);
-
-    let base_request = build_base_request(client, url, reqwest::Method::GET);
-
-    let request = match base_request {
-        Ok(request) => request,
-        Err(e) => return Err(e),
-    };
+    let base_request = build_base_request(client, url, reqwest::Method::GET).await?;
 
     let token = match client.auth.access_token {
         Some(ref token) => format!("Bearer {}", token),
@@ -56,7 +50,7 @@ pub async fn list_secrets_request(
     debug!("Creating secret with JSON body: {:?}", json);
     debug!("Creating secret with url: {}", url);
 
-    let response = request.json(json).send().await?;
+    let response = base_request.json(json).send().await?;
     let status = response.status();
 
     if status == StatusCode::OK {

--- a/crates/infisical/src/api/secrets/update_secret.rs
+++ b/crates/infisical/src/api/secrets/update_secret.rs
@@ -26,14 +26,9 @@ pub async fn update_secret_request(
 
     });
 
-    let base_request = build_base_request(client, &base_url, reqwest::Method::PATCH);
+    let base_request = build_base_request(client, &base_url, reqwest::Method::PATCH).await?;
 
-    let request = match base_request {
-        Ok(request) => request,
-        Err(e) => return Err(e),
-    };
-
-    let response = request.json(json).send().await?;
+    let response = base_request.json(json).send().await?;
     let status = response.status();
 
     if status == StatusCode::OK {

--- a/crates/infisical/src/client/client.rs
+++ b/crates/infisical/src/client/client.rs
@@ -10,6 +10,7 @@ pub struct Client {
 
     pub(crate) cache: Arc<Mutex<Vec<CachedSecret>>>,
     pub(crate) cache_ttl: u64, // No need for a mutex lock here, as we are only reading this value in the cache thread.
+    pub(crate) ssl_certificate_path: Option<String>,
 
     pub site_url: String,
     pub user_agent: String,
@@ -35,6 +36,7 @@ impl Client {
 
         let client: Client = Self {
             auth: settings.auth,
+            ssl_certificate_path: settings.ssl_certificate_path,
             site_url: settings
                 .site_url
                 .unwrap_or("https://app.infisical.com".to_string()),

--- a/crates/infisical/src/client/client_settings.rs
+++ b/crates/infisical/src/client/client_settings.rs
@@ -1,8 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::constants::INFISICAL_SSL_CERTIFICATE_ENV_NAME;
-
 use super::auth_method_settings::AuthenticationOptions;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]

--- a/crates/infisical/src/client/client_settings.rs
+++ b/crates/infisical/src/client/client_settings.rs
@@ -1,6 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::constants::INFISICAL_SSL_CERTIFICATE_ENV_NAME;
+
 use super::auth_method_settings::AuthenticationOptions;
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
@@ -37,6 +39,11 @@ pub struct ClientSettings {
     pub user_agent: Option<String>, // We use this to identity which SDK/language was used to make a request.
 
     #[schemars(
+        description = "The SSL certificate path is an optional field that allows you to specify a custom SSL certificate to use for requests made to Infisical."
+    )]
+    pub ssl_certificate_path: Option<String>, // Path to the SSL certificate file.
+
+    #[schemars(
         description = "Configure the authentication method to use.\n\nMake sure to only set one one method at a time to avoid conflicts and unexpected behavior."
     )]
     pub auth: AuthenticationOptions,
@@ -46,6 +53,7 @@ pub struct ClientSettings {
 impl Default for ClientSettings {
     fn default() -> Self {
         Self {
+            ssl_certificate_path: None,
             client_secret: None,
             client_id: None,
             access_token: None,

--- a/crates/infisical/src/constants.rs
+++ b/crates/infisical/src/constants.rs
@@ -29,3 +29,5 @@ pub const AWS_EC2_INSTANCE_IDENTITY_DOCUMENT_URL: &str =
 // Azure Metadata Service:
 pub const AZURE_METADATA_SERVICE_URL: &str =
     "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F";
+
+pub const INFISICAL_SSL_CERTIFICATE_ENV_NAME: &str = "INFISICAL_SSL_CERTIFICATE";

--- a/crates/infisical/src/error.rs
+++ b/crates/infisical/src/error.rs
@@ -18,6 +18,12 @@ pub enum Error {
     #[error("Something unexpected went wrong.")]
     UnknownError,
 
+    #[error("Failed to find SSL/TLS certificate")]
+    SSLCertificateNotFound,
+
+    #[error("Invalid SSL/TLS certificate, {}", .message)]
+    InvalidSSLCertificate { message: String },
+
     #[error("Something went wrong: {}", .message)]
     UnknownErrorWithMessage { message: String },
 

--- a/crates/infisical/tests/cryptography.rs
+++ b/crates/infisical/tests/cryptography.rs
@@ -41,6 +41,7 @@ fn create_client() -> Client {
         client_id: None,
         client_secret: None,
         access_token: None,
+        ssl_certificate_path: None,
 
         auth: AuthenticationOptions {
             gcp_iam: None,

--- a/crates/infisical/tests/secrets.rs
+++ b/crates/infisical/tests/secrets.rs
@@ -107,6 +107,7 @@ fn create_client() -> Client {
         client_id: Some(environment.client_id),
         client_secret: Some(environment.client_secret),
         access_token: None,
+        ssl_certificate_path: None,
 
         site_url: Some(environment.site_url),
         cache_ttl: None,


### PR DESCRIPTION
This PR introduces support for custom / self-signed certificates that aren't present in the root store or webPKI store.

The user is given two options on how they want to pass in the certificate
1. The path to the certificate. This is passed when initializing the Infisical client in the respective language.
2. An environment variable containing the full certificate. If no path is provided, we check internally for an environment variable containing the certificate.

There are quite a few files changed, because we need to ensure all the requests being sent by the SDK is covered by the TLS support.

There's a new `build_minimal_base_request` function, which doesn't factor in the SSL certificate. This function is used when sending requests to non-Infisical hosts like GCP or AWS.