### PR TITLE
Fix: C bindings for Linux musl x86

### DIFF
--- a/.github/workflows/build-c-bindings.yml
+++ b/.github/workflows/build-c-bindings.yml
@@ -23,6 +23,8 @@ jobs:
                       target: aarch64-unknown-linux-gnu
                     - os: ubuntu-22.04
                       target: aarch64-unknown-linux-musl
+                    - os: ubuntu-22.04
+                      target: x86_64-unknown-linux-musl
 
         steps:
             - name: Checkout
@@ -54,15 +56,21 @@ jobs:
                   tar -xzf aarch64-linux-musl-cross.tgz
                   echo "$PWD/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
 
-            - name: Build Rust (Normal)
-              if: matrix.settings.target != 'aarch64-unknown-linux-musl'
+            - name: Install cross-compilation tools for x86_64-musl
+              if: matrix.settings.target == 'x86_64-unknown-linux-musl'
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y musl-tools
+
+            - name: Build Rust (GNU/Others)
+              if: ${{ !endsWith(matrix.settings.target, '-linux-musl') }}
               env:
                   RUSTFLAGS: "-D warnings"
                   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
               run: cargo build --target ${{ matrix.settings.target }} --release --workspace --exclude infisical-py
 
             - name: Build Rust (Musl)
-              if: matrix.settings.target == 'aarch64-unknown-linux-musl'
+              if: endsWith(matrix.settings.target, '-linux-musl')
               env:
                   RUSTFLAGS: "-D warnings -C target-feature=-crt-static"
                   CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-musl-gcc

--- a/.github/workflows/build-c-bindings.yml
+++ b/.github/workflows/build-c-bindings.yml
@@ -80,7 +80,7 @@ jobs:
               uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
               with:
                   name: libinfisical_c_files-${{ matrix.settings.target }}
-                  path: |
+                  path: | # .so for linux, .dll for windows, .dylib for darwin/macos
                       target/${{ matrix.settings.target }}/release/*infisical_c*.so
                       target/${{ matrix.settings.target }}/release/*infisical_c*.dll
                       target/${{ matrix.settings.target }}/release/*infisical_c*.dylib

--- a/.github/workflows/build-c-bindings.yml
+++ b/.github/workflows/build-c-bindings.yml
@@ -81,4 +81,6 @@ jobs:
               with:
                   name: libinfisical_c_files-${{ matrix.settings.target }}
                   path: |
-                      target/${{ matrix.settings.target }}/release/*infisical_c*
+                      target/${{ matrix.settings.target }}/release/*infisical_c*.so
+                      target/${{ matrix.settings.target }}/release/*infisical_c*.dll
+                      target/${{ matrix.settings.target }}/release/*infisical_c*.dylib

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -3,8 +3,8 @@ run-name: Release Java SDK
 
 on:
     push:
-        # tags:
-        #     - "*.*.*" # version, e.g. 1.0.0
+        tags:
+            - "*.*.*" # version, e.g. 1.0.0
 
 jobs:
     generate_schemas:
@@ -111,13 +111,13 @@ jobs:
                   echo "Listing files in languages/java/src/main/resources:"
                   ls -R languages/java/src/main/resources
 
-            # - name: Publish Maven
-            #   working-directory: languages/java
-            #   run: |
-            #       ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
-            #   env:
-            #       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
-            #       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
-            #       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
-            #       ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID }} # Last 8 characters of the full key ID
-            #       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}
+            - name: Publish Maven
+              working-directory: languages/java
+              run: |
+                  ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+              env:
+                  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+                  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
+                  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
+                  ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID }} # Last 8 characters of the full key ID
+                  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -100,7 +100,7 @@ jobs:
                   mv languages/java/src/main/resources/linux-aarch64-gnu/libinfisical_c.so languages/java/src/main/resources/linux-aarch64/libinfisical_c_aarch64_gnu.so
                   mv languages/java/src/main/resources/linux-aarch64-musl/libinfisical_c.so languages/java/src/main/resources/linux-aarch64/libinfisical_c_aarch64_musl.so
 
-                  mv languages/java/src/main/resources/linux-x86-64-musl/libinfisical_c.so languages/java/src/main/resources/linux-x86-64-musl/libinfisical_c_x64_musl.so
+                  mv languages/java/src/main/resources/linux-x86-64-musl/libinfisical_c.so languages/java/src/main/resources/linux-x86-64/libinfisical_c_x64_musl.so
 
                   rm -rf languages/java/src/main/resources/linux-aarch64-musl
                   rm -rf languages/java/src/main/resources/linux-x86-64-musl

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -3,8 +3,8 @@ run-name: Release Java SDK
 
 on:
     push:
-        tags:
-            - "*.*.*" # version, e.g. 1.0.0
+        # tags:
+        #     - "*.*.*" # version, e.g. 1.0.0
 
 jobs:
     generate_schemas:
@@ -45,36 +45,49 @@ jobs:
                   distribution: temurin
                   java-version: 21
 
+            # x86/x64 GNU bindings (MacOS)
             - name: Download x86_64-apple-darwin files
               uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
               with:
                   name: libinfisical_c_files-x86_64-apple-darwin
                   path: languages/java/src/main/resources/darwin-x86-64
 
+            # Aarch64 GNU bindings (MacOS)
             - name: Download aarch64-apple-darwin files
               uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
               with:
                   name: libinfisical_c_files-aarch64-apple-darwin
                   path: languages/java/src/main/resources/darwin-aarch64
 
+            # x86/x64 GNU bindings (LINUX)
             - name: Download x86_64-unknown-linux-gnu files
               uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
               with:
                   name: libinfisical_c_files-x86_64-unknown-linux-gnu
                   path: languages/java/src/main/resources/linux-x86-64
 
+            # Aarch64 GNU bindings (LINUX)
             - name: Download aarch64-unknown-linux-gnu files
               uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
               with:
                   name: libinfisical_c_files-aarch64-unknown-linux-gnu
                   path: languages/java/src/main/resources/linux-aarch64-gnu
 
+            # Aarch64 Musl bindings (LINUX)
             - name: Download aarch64-unknown-linux-musl files
               uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
               with:
                   name: libinfisical_c_files-aarch64-unknown-linux-musl
                   path: languages/java/src/main/resources/linux-aarch64-musl
 
+            # x86/x64 Musl bindings (LINUX)
+            - name: Download x86_64-unknown-linux-musl files
+              uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+              with:
+                  name: libinfisical_c_files-x86_64-unknown-linux-musl
+                  path: languages/java/src/main/resources/linux-x86-64-musl
+
+            # x86/x64 Musl bindings (Windows)
             - name: Download x86_64-pc-windows-msvc files
               uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
               with:
@@ -84,9 +97,13 @@ jobs:
             - name: Organize and rename Linux ARM64 libraries
               run: |
                   mkdir -p languages/java/src/main/resources/linux-aarch64
-                  mv languages/java/src/main/resources/linux-aarch64-gnu/libinfisical_c.so languages/java/src/main/resources/linux-aarch64/libinfisical_c_gnu.so
-                  mv languages/java/src/main/resources/linux-aarch64-musl/libinfisical_c.so languages/java/src/main/resources/linux-aarch64/libinfisical_c_musl.so
+                  mv languages/java/src/main/resources/linux-aarch64-gnu/libinfisical_c.so languages/java/src/main/resources/linux-aarch64/libinfisical_c_aarch64_gnu.so
+                  mv languages/java/src/main/resources/linux-aarch64-musl/libinfisical_c.so languages/java/src/main/resources/linux-aarch64/libinfisical_c_aarch64_musl.so
+
+                  mv languages/java/src/main/resources/linux-x86-64-musl/libinfisical_c.so languages/java/src/main/resources/linux-x86-64-musl/libinfisical_c_x64_musl.so
+
                   rm -rf languages/java/src/main/resources/linux-aarch64-musl
+                  rm -rf languages/java/src/main/resources/linux-x86-64-musl
                   rm -rf languages/java/src/main/resources/linux-aarch64-gnu
 
             - name: List files in resources folders
@@ -94,13 +111,13 @@ jobs:
                   echo "Listing files in languages/java/src/main/resources:"
                   ls -R languages/java/src/main/resources
 
-            - name: Publish Maven
-              working-directory: languages/java
-              run: |
-                  ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
-              env:
-                  ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
-                  ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
-                  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
-                  ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID }} # Last 8 characters of the full key ID
-                  ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}
+            # - name: Publish Maven
+            #   working-directory: languages/java
+            #   run: |
+            #       ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+            #   env:
+            #       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+            #       ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
+            #       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
+            #       ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID }} # Last 8 characters of the full key ID
+            #       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}

--- a/languages/java/src/main/java/com/infisical/sdk/InfisicalClient.java
+++ b/languages/java/src/main/java/com/infisical/sdk/InfisicalClient.java
@@ -42,7 +42,8 @@ public class InfisicalClient implements AutoCloseable {
             } else {
               // We build the default bindings for x86_64, so no need to specify a custom
               // library path for this.
-              libraryName = "infisical_c";
+              // Therefore there's no need to set the libraryName variable here, because it defaults to "infisical_c".
+              // libraryName = "infisical_c";
             }
           }
         }

--- a/languages/java/src/main/java/com/infisical/sdk/InfisicalClient.java
+++ b/languages/java/src/main/java/com/infisical/sdk/InfisicalClient.java
@@ -25,13 +25,27 @@ public class InfisicalClient implements AutoCloseable {
         String arch = System.getProperty("os.arch");
         String os = System.getProperty("os.name").toLowerCase();
 
-        if (os.contains("linux") && arch.equals("aarch64")) {
-          if (isMusl()) {
-              libraryName = "infisical_c_musl";
-          } else {
-              libraryName = "infisical_c_gnu";
+        if (os.contains("linux")) {
+
+          // Aarch64 specific bindings (gnu/musl determinations)
+          if (arch.equals("aarch64")) {
+            if (isMusl()) {
+              libraryName = "infisical_c_aarch64_musl";
+            } else {
+              libraryName = "infisical_c_aarch64_gnu";
+            }
           }
-        } 
+          // x86_64 specific bindings (gnu/musl determinations)
+          else if (arch.equals("amd64") || arch.equals("x86_64")) {
+            if (isMusl()) {
+              libraryName = "libinfisical_c_x64_musl";
+            } else {
+              // We build the default bindings for x86_64, so no need to specify a custom
+              // library path for this.
+              libraryName = "infisical_c";
+            }
+          }
+        }
 
         library = Native.load(libraryName, InfisicalLibrary.class);
 


### PR DESCRIPTION
We cover linux musl for aarch64 already, but x86 was a missed case, which is now addressed in this PR. Additionally, this PR also **significantly** reduces the size of all SDK's, because we are no longer including unnecessary library files such as .a files. We are using shared libraries for runtime loading, so there's no need to include statically built library files.